### PR TITLE
Fix adding extra empty record. Resolves #1

### DIFF
--- a/web/form.xhtml
+++ b/web/form.xhtml
@@ -25,7 +25,7 @@
         <h:commandButton value="Add"
                          type="submit"
                          styleClass="button"
-                         onclick="#{carService.create(id.value, man.value, model.value, license.value)}"/>
+                         action="#{carService.create(id.value, man.value, model.value, license.value)}"/>
     </h:form>
 
     <h:button styleClass="button" value="to main" outcome="index"/>


### PR DESCRIPTION
`onclick` attribute is used to define JavaScript actions not
Java bindings and thus evaluated on page load. This lead to empty record
creation on form page load.
Replacing `onclick` with `action` fixes this problem as `action` is used
to define Java bindings in JSF command components.